### PR TITLE
Enable MS Teams notifications in addition to slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Sally the Slier Siren
+# Sally the Sliver Siren
 
-A custom sliver client that will send slack notifications upon new beacons / sessions that check in. Can either be run with a config file (that will be reloaded after `sleep` number of seconds, except for the `sliver_config` as the intial connection is used for all checks).
+A custom sliver client that will send slack or teams notifications upon new beacons / sessions that check in. Can either be run with a config file (that will be reloaded after `sleep` number of seconds, except for the `sliver_config` as the intial connection is used for all checks).
 
 ## Usage
 
@@ -13,20 +13,22 @@ pip3 install -r requirements.txt
 Once all dependencies are installed, you can then run the python script (which will run continuously).
 
 ```
-usage: sally.py [-h] [-c CONFIG] [-S SLIVER_CONFIG] [-u SLACK_URL] [-s SLEEP]
+usage: sally.py [-h] [-c CONFIG] [-S SLIVER_CONFIG] [-u URL] [-p PROVIDER] [-s SLEEP]
 
 Custom Sliver client that will will emit events and send webhook notifications when new beacons / sessions check in.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -c CONFIG, --config CONFIG
                         Path to sally config file (which will immediately take effect as changes to Sally)
   -S SLIVER_CONFIG, --sliver_config SLIVER_CONFIG
                         Path to the sliver config to connect with
-  -u SLACK_URL, --slack_url SLACK_URL
-                        Slack URL to send notifications to
+  -u URL, --url URL     Webhook URL to send notifications to
+  -p PROVIDER, --provider PROVIDER
+                        Slack or Teams
   -s SLEEP, --sleep SLEEP
                         Sleep time in between checking for changes in beacons / sessions
+
 ```
 
 ### Usage with Command Line
@@ -34,7 +36,7 @@ optional arguments:
 If you want to run the command using only the command line arguments, a sample command would look like the following:
 
 ```bash
-python3 ./sally.py -S /path/to/sliver-config.conf -s 10 -u https://slack.com
+python3 ./sally.py -S /path/to/sliver-config.conf -s 10 -p slack -u https://slack.com
 ```
 
 ### Usage with Config File

--- a/config_example.yml
+++ b/config_example.yml
@@ -1,3 +1,4 @@
-sliver_config: /opt/container/sliver/mount/sally-the-sliver-siren.conf
-slack_url: https://slack.com
+sliver_config: /home/username/.sliver-client/configs/username_localhost.cfg
+provider: slack # values can be: teams or slack
+url: https://hooks.slack.com/services/1234/5678/4321 # https://contoso.webhook.office.com/webhookb2/GUID@GUID/IncomingWebhook/IDstring/etc
 sleep_time: 10

--- a/sally.py
+++ b/sally.py
@@ -1,25 +1,23 @@
 #!/usr/bin/env python3
 
-import asyncio
-from nis import cat
+import asyncio, os, argparse, requests, yaml
 from pathlib import Path
 from time import sleep
-import argparse
-import requests
 from sliver import *
-import yaml
 
 async def main():
     parser = argparse.ArgumentParser(description='Custom Sliver client that will will emit events and send webhook notifications when new beacons / sessions check in.')
     parser.add_argument('-c', '--config', type=Path, help='Path to sally config file (which will immediately take effect as changes to Sally)')
     parser.add_argument('-S', '--sliver_config', default=None, type=Path, help='Path to the sliver config to connect with')
-    parser.add_argument('-u', '--slack_url', default=None, type=str, help='Slack URL to send notifications to' )
+    parser.add_argument('-u', '--url', default=None, type=str, help='Webhook URL to send notifications to' )
+    parser.add_argument('-p', '--provider', default=None, type=str, help='Slack or Teams' )
     parser.add_argument('-s', '--sleep', type=int, default=10, help='Sleep time in between checking for changes in beacons / sessions')
 
     args = parser.parse_args()
     sally_config = args.config
     sliver_config = args.sliver_config
-    slack_url = args.slack_url
+    provider = args.provider
+    webhook_url = args.url
     sleep_time = args.sleep
 
     # Flag to represent if we are using a config file
@@ -27,14 +25,15 @@ async def main():
 
     if sally_config and not sliver_config and not sliver_config:
         using_config = True
-        sliver_config, slack_url, sleep_time = read_config(sally_config)
+        sliver_config, provider, webhook_url, sleep_time = read_config(sally_config)
 
-    if not sliver_config.exists():
-        print('[X] Sliver config not found at location provided')
+    if not os.path.exists(sliver_config):
+        print('[X] Sliver config not found at ' + str(sliver_config))
         exit(1)
 
     config = SliverClientConfig.parse_config_file(sliver_config)
     client = SliverClient(config)
+
     print('[*] Connecting to Sliver Server...')
     await client.connect()
     print('[*] Connected to Sliver Server!')
@@ -62,12 +61,15 @@ async def main():
                 new_beacon_data = [
                     selected_beacon for selected_beacon in current_beacons if selected_beacon.ID == new_beacon]
                 new_beacon_data = new_beacon_data[0]
-                post_data = generate_slack_message(new_beacon_data, 'beacon')
-
+                if str(provider).lower() == 'teams':
+                    post_data = generate_teams_message(new_beacon_data, 'beacon')
+                elif str(provider).lower() == 'slack':
+                    post_data = generate_slack_message(new_beacon_data, 'beacon')
                 print(f'[*] Sending message about beacon {new_beacon}')
                 try:
-                    resp = requests.post(slack_url, json=post_data)
+                    resp = requests.post(webhook_url, json=post_data)
                     print(f'[*] Sent message: HTTP ({resp.status_code})')
+
                 except:
                     print(f'[X] Something went wrong when sending webhook message, check the URL used')
                 
@@ -83,12 +85,16 @@ async def main():
                 new_session_data = [
                     selected_session for selected_session in current_sessions if selected_session.ID == new_session]
                 new_session_data = new_session_data[0]
-                post_data = generate_slack_message(new_session_data, 'session')
+                if str(provider).lower() == 'teams':
+                    post_data = generate_teams_message(new_session_data, 'session')
+                elif str(provider).lower() == 'slack':
+                    post_data = generate_slack_message(new_session_data, 'session')
 
                 print(f'[*] Sending message about session {new_session}')
                 try:
-                    resp = requests.post(slack_url, json=post_data)
+                    resp = requests.post(webhook_url, json=post_data)
                     print(f'[*] Sent message: HTTP ({resp.status_code})')
+
                 except:
                     print(f'[X] Something went wrong when sending webhook message, check the URL used')
             
@@ -100,7 +106,7 @@ async def main():
 
         # Get new config values
         if using_config:
-            sliver_config, slack_url, sleep_time = read_config(sally_config)
+            sliver_config, provider, webhook_url, sleep_time = read_config(sally_config)
 
    
 
@@ -108,7 +114,7 @@ def read_config(config_path):
     config_file = Path(config_path).read_text()
     config_file_yaml = yaml.safe_load(config_file)
 
-    return config_file_yaml['sliver_config'], config_file_yaml['slack_url'], config_file_yaml['sleep_time']
+    return config_file_yaml['sliver_config'], config_file_yaml['provider'], config_file_yaml['url'], config_file_yaml['sleep_time']
 
 
 def extract_uuid(beacon_list):
@@ -116,6 +122,43 @@ def extract_uuid(beacon_list):
 
     return set(beacon_uuids)
 
+def generate_teams_message(data, type='beacon'):
+    
+    header_text = '🚨  New Sliver '
+    
+    if type == 'beacon':
+        header_text += 'Beacon'
+    elif type == 'session':
+        header_text += 'Session'
+    else:
+        header_text += 'Event'
+
+    post_data = {
+    "@type": "MessageCard",
+    "@context": "http://schema.org/extensions",
+    "themeColor": "0076D7",
+    "summary": header_text,
+    "sections": [{
+        "activityTitle": header_text,
+        "activitySubtitle": "C2 Domain: " + data.ActiveC2,
+        "activityImage": "https://images.bishopfox.com/prod-1437/Images/global/main-menu/poly-fox-graphic.png",
+        "facts": [{
+            "name": "Hostname",
+            "value": data.Hostname
+        }, {
+            "name": "Username",
+            "value": data.Username
+        }, {
+            "name": "Process ID",
+            "value": data.PID
+        }, {
+            "name": "OS",
+            "value": data.OS
+        }],
+        "markdown": "true"
+    }]
+    }
+    return post_data
 
 def generate_slack_message(data, type='beacon'):
     header_text = '🚨  New Sliver '


### PR DESCRIPTION
Added functionality to produce MS teams notifications through incoming webhooks, while leaving the slack webhook functions intact. Tested with both slack and teams, beacons and sessions. 